### PR TITLE
feat: move base URL to credentials for n8n Connect support

### DIFF
--- a/credentials/PdfcoApi.credentials.ts
+++ b/credentials/PdfcoApi.credentials.ts
@@ -20,7 +20,14 @@ export class PdfcoApi implements ICredentialType {
 				password: true,
 			},
 			hint: `To get your PDF.co API key please <a href="https://app.pdf.co/signup?utm_source=n8n&utm_medium=sign-up">click here to create your account</a>`,
+		},
+		{
+			displayName: 'Base URL',
+			name: 'baseUrl',
+			type: 'hidden',
+			default: 'https://api.pdf.co',
 		}
+
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -36,7 +43,7 @@ export class PdfcoApi implements ICredentialType {
 	// The block below tells how this credential can be tested
 	test: ICredentialTestRequest = {
 		request: {
-			url: `${PDFCO_CONSTANTS.BASE_URL}/v1/account/credit/balance`,
+			url: '={{$credentials?.baseUrl}}/v1/account/credit/balance',
 		},
 	};
 }

--- a/nodes/PdfCo/Descriptions.ts
+++ b/nodes/PdfCo/Descriptions.ts
@@ -196,5 +196,5 @@ export const descriptions: INodeTypeDescription = {
 		...uploadFile.description,
 	],
 	subtitle: '={{$parameter["operation"]}}',
-	version: 1,
+	version: [1, 1.1],
 };

--- a/nodes/PdfCo/GenericFunctions.ts
+++ b/nodes/PdfCo/GenericFunctions.ts
@@ -7,12 +7,17 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
+
+interface PdfcoCredentials {
+	apiKey: string;
+	baseUrl: string;
+}
 import { NodeApiError } from 'n8n-workflow';
 import { PDFCO_CONSTANTS } from './constants';
 
 async function delay(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
-	ms: number
+	ms: number,
 ): Promise<void> {
 	await pdfcoApiRequest.call(this, '/v1/delay', {}, 'GET', { val: ms });
 }
@@ -25,8 +30,9 @@ export async function pdfcoApiRequest(
 	qs: IDataObject = {},
 	option: IDataObject = {},
 ): Promise<any> {
-	const credentials = await this.getCredentials('pdfcoApi');
-	const baseURL = this.getNode().typeVersion >= 1.1 ? credentials.baseUrl : PDFCO_CONSTANTS.BASE_URL;
+	const credentials = (await this.getCredentials('pdfcoApi')) as unknown as PdfcoCredentials;
+	const baseURL =
+		this.getNode().typeVersion >= 1.1 ? credentials.baseUrl : PDFCO_CONSTANTS.BASE_URL;
 	let options: IRequestOptions = {
 		baseURL,
 		url: url,
@@ -365,7 +371,7 @@ export async function loadResource(this: ILoadOptionsFunctions, resource: string
 			{ name: 'Uzbek', value: 'uzb' },
 			{ name: 'Uzbek - Cyrillic', value: 'uzb_cyrl' },
 			{ name: 'Vietnamese', value: 'vie' },
-			{ name: 'Yiddish', value: 'yid' }
+			{ name: 'Yiddish', value: 'yid' },
 		];
 	}
 	return [];

--- a/nodes/PdfCo/GenericFunctions.ts
+++ b/nodes/PdfCo/GenericFunctions.ts
@@ -26,8 +26,9 @@ export async function pdfcoApiRequest(
 	option: IDataObject = {},
 ): Promise<any> {
 	const credentials = await this.getCredentials('pdfcoApi');
+	const baseURL = this.getNode().typeVersion >= 1.1 ? credentials.baseUrl : PDFCO_CONSTANTS.BASE_URL;
 	let options: IRequestOptions = {
-		baseURL: PDFCO_CONSTANTS.BASE_URL,
+		baseURL,
 		url: url,
 		headers: {
 			'content-type': 'application/json',


### PR DESCRIPTION
## Summary

- Adds a hidden `baseUrl` field to `PdfcoApi` credentials, defaulting to `https://api.pdf.co` — this allows n8n Connect to inject a proxied base URL at runtime
- Bumps node `typeVersion` to `1.1` so new credential-aware URL resolution is used on fresh installs, while existing nodes (typeVersion 1) continue using the hardcoded constant (no breaking change)
- Updates the credential test request to use `={{$credentials?.baseUrl}}` instead of the hardcoded constant

## Why

n8n Connect requires the base URL to be configurable via credentials rather than hardcoded in the node. Using `typeVersion` gating ensures backward compatibility with nodes already installed by users, n8n Connect will be shown for version 1.1+

